### PR TITLE
Fix token not getting saved on first login

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,8 +8,8 @@ import { UserContext } from "./contexts/UserContext";
 import Navbar from "./components/shared/Navbar";
 
 export default function App() {
-	const userID = localStorage.getItem("userID");
-	const token = localStorage.getItem("token");
+	let userID = localStorage.getItem("userID");
+	let token = localStorage.getItem("token");
 
 	return (
 		<S.App>

--- a/src/screens/LogIn/LogIn.js
+++ b/src/screens/LogIn/LogIn.js
@@ -15,11 +15,7 @@ export default function LogIn() {
 		if (token) {
 			getTrendingHashtags(token)
 				.then(() => history.push("/timeline"))
-				.catch((res) => {
-					if (res.response.status === 403) {
-						alert("sua sessão expirou. logue-se novamente");
-					}
-				});
+				.catch(() => null);
 		}
 	}
 

--- a/src/screens/Timeline/index.js
+++ b/src/screens/Timeline/index.js
@@ -26,7 +26,9 @@ export default function Timeline() {
 				setIsLoading(false);
 			},
 			(err) => {
-				alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				if (token) {
+					alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				}
 				setIsLoading(false);
 			}
 		);

--- a/src/screens/Timeline/index.js
+++ b/src/screens/Timeline/index.js
@@ -1,6 +1,5 @@
 import { getAllPosts } from "../../services/linkr-api";
-import { useContext, useState, useEffect } from "react";
-import { UserContext } from "../../contexts/UserContext";
+import { useState, useEffect } from "react";
 import Post from "../../components/Post";
 import Loader from "../../components/Loader";
 import { PageWrapper, PageTitle } from "../../components/shared/CommonStyled";
@@ -14,10 +13,10 @@ import {
 } from "./style";
 
 export default function Timeline() {
-	const { token } = useContext(UserContext);
 	const [timelinePosts, setTimelinePosts] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
-
+	const token = localStorage.getItem('token');
+	
 	useEffect(fetchPosts, [token]);
 
 	function fetchPosts() {


### PR DESCRIPTION
- A timeline agora não pega os dados do userContext, mas sim do localStorage.
    O useContext foi utilizado antes da implementação do login persistente.
    Agora, com a informação guardada no localStorage, não vejo necessidade de guardar ela também no useContext. 
    É mais trabalho ficar atualizando uma informação fixa, que não muda durante a sessão, em dois lugares. 

- Removi o alerta de falha ao recarregar os posts caso a falha esteja no token;
    A navbar já verifica se o token é válido, manda um alerta avisando sobre isso, e atualiza a página.
    Como, a timeline também manda esse aviso, dois alertas são enviados pelo mesmo motivo;