### PR TITLE
Posts loading fix

### DIFF
--- a/src/screens/MyLikes/index.js
+++ b/src/screens/MyLikes/index.js
@@ -14,7 +14,7 @@ import {
 import TrendingContainer from "../../components/TrendingContainer";
 
 export default function MyLikes() {
-	const { token } = useContext(UserContext);
+	const token = localStorage.getItem("token");
 	const [likedPosts, setLikedPosts] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 
@@ -27,7 +27,9 @@ export default function MyLikes() {
 				setIsLoading(false);
 			},
 			(err) => {
-				alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				if (token) {
+					alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				}
 				setIsLoading(false);
 			}
 		);

--- a/src/screens/MyPosts/index.js
+++ b/src/screens/MyPosts/index.js
@@ -16,7 +16,8 @@ import { getUserPosts } from "../../services/linkr-api";
 export default function MyPosts() {
 	const [posts, setPosts] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
-	const { token, userID } = useContext(UserContext);
+	const token = localStorage.getItem("token");
+	const userID = localStorage.getItem('userID')
 
 	useEffect(fetchPosts, [token, userID]);
 

--- a/src/screens/MyPosts/index.js
+++ b/src/screens/MyPosts/index.js
@@ -28,7 +28,9 @@ export default function MyPosts() {
 				setIsLoading(false);
 			},
 			() => {
-				alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				if (token) {
+					alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				}
 				setIsLoading(false);
 			}
 		);

--- a/src/screens/UserPosts/index.js
+++ b/src/screens/UserPosts/index.js
@@ -19,7 +19,7 @@ export default function UserPosts() {
 	const [posts, setPosts] = useState([]);
 	const [name, setName] = useState("");
 	const [isLoading, setIsLoading] = useState(true);
-	const { token } = useContext(UserContext);
+	const token = localStorage.getItem("token");
 
 	useEffect(fetchPosts, [token, id]);
 

--- a/src/screens/UserPosts/index.js
+++ b/src/screens/UserPosts/index.js
@@ -30,7 +30,9 @@ export default function UserPosts() {
 				setIsLoading(false);
 			},
 			() => {
-				alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				if (token) {
+					alert("Houve uma falha ao obter os posts, por favor atualize a página");
+				}
 				setIsLoading(false);
 			}
 		);

--- a/src/screens/UserPosts/index.js
+++ b/src/screens/UserPosts/index.js
@@ -38,10 +38,13 @@ export default function UserPosts() {
 		);
 	}
 
-	getUserInfo({ token, userID: id }).then(
-		(res) => setName(res.data.user.username),
-		() => alert("Houve uma falha ao encontrar o usuário buscado")
-	);
+	getUserInfo({ token, userID: id })
+		.then((res) => setName(res.data.user.username))
+		.catch(()=>{
+			if (token) {
+				alert("Houve uma falha ao encontrar o usuário buscado");	
+			}	
+		});
 
 	return (
 		<PageWrapper>


### PR DESCRIPTION
Fixei os problemas relacionados ao carregamento de posts.
A solução foi fazer as paginas pegarem o token e userID do localStorage ao invés do userContext;
Também removi os alertas do tipo "usuario nao encontrado' e 'posts não encontrado atualize a pagina' caso o problema seja usuário não logado. Um alerta dizendo que a sessão expirou aparece no lugar.